### PR TITLE
Fix unicode issue when copying page

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,8 @@
                     + (document.doctype.systemId ? ' "' + document.doctype.systemId + '"' : '')
                     + '>';
                 css.innerHTML = css.innerHTML.replace(/<br>/g, '\n');
-                clipboardCopy('data:text/html;base64,' + btoa(doctype + document.documentElement.outerHTML));
+                const b64Data = btoa(unescape(encodeURIComponent(doctype + document.documentElement.outerHTML)));
+                clipboardCopy('data:text/html;base64,' + b64Data);
             };
 
             window.onload = () => {


### PR DESCRIPTION
Fix the following error aborting copy to clipboard feature on your [web page](https://frontendlane.github.io/page-source/):
```
Uncaught DOMException: Failed to execute 'btoa' on 'Window': The string to be encoded contains characters outside of the Latin1 range.
    at HTMLAnchorElement.copyPage
```